### PR TITLE
Refactor the parser to use a switch statement 

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -17,67 +17,170 @@ class Parser extends EventEmitter {
         var match = null;
         var result = null;
 
-        if (line.match(/^Initialize engine version/)) {
+        var initializeEngineVersion = function(){
+          if(line.match(/^Initialize engine version/)) {
             result = ["startup"];
+            return true;
+          }
+        };
 
-        } else if (line.match(/\[Power\] .* Begin Spectating/)) {
+        var beginSpectatorMode = function() {
+          if(line.match(/\[Power\] .* Begin Spectating/)) {
             result = ["begin_spectator_mode"];
+            return true;
+          }
+        };
 
-        } else if (line.match(/\[Power\] .* End Spectator/)) {
+        var endSpectatorMode = function() {
+          if(line.match(/\[Power\] .* End Spectator/)) {
             result = ["end_spectator_mode"];
+            return true;
+          }
+        };
 
-        } else if (match = line.match(/\[LoadingScreen\] LoadingScreen.OnSceneLoaded\(\) - prevMode=.* currMode=(.*)/)) {
-            var mode = match[1];
-            switch(mode) {
-                case "DRAFT":
-                    result = ["mode", "arena"];
-                    break;
-                case "TOURNAMENT":
-                    result = ["mode", "ranked"];
-                    break;
-                case "ADVENTURE":
-                    result = ["mode", "solo"];
-                    break;
+        var detectCurrentMode = function() {
+            var match = line.match(/\[LoadingScreen\] LoadingScreen.OnSceneLoaded\(\) - prevMode=.* currMode=(.*)/);
+            if (match) {
+                var mode = match[1];
+                switch (mode) {
+                    case "DRAFT":
+                        result = ["mode", "arena"];
+                        return true;
+                    case "TOURNAMENT":
+                        result = ["mode", "ranked"];
+                        return true;
+                    case "ADVENTURE":
+                        result = ["mode", "solo"];
+                        return true;
+                }
             }
+        };
 
-        } else if (match = line.match(/TAG_CHANGE Entity=\[.*id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d)\] tag=(.*) value=(.*)/)) {
-            var [, entityId, zone, zonePos, cardId, playerId, type, state] = match;
-            result = this.parseTagChange(type, null, state, parseInt(playerId), parseInt(entityId), zone, parseInt(zonePos), cardId);
+        /*
+         * This function tracks tag changes related to damage, attacking, defending, card target, armor, attack, and health
+         */
+        var detectChangeWithDetails = function(){
+          var match = line.match(/TAG_CHANGE Entity=\[.*id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d)\] tag=(.*) value=(.*)/);
+          if (match) {
+              var [, entityId, zone, zonePos, cardId, playerId, type, state] = match;
+              result = this.parseTagChange(type, null, state, parseInt(playerId), parseInt(entityId), zone, parseInt(zonePos), cardId);
+              return true;
+          }
+        };
 
-        } else if (match = line.match(/TAG_CHANGE Entity=(.*) tag=(.*) value=(.*)/)) {
+        /*
+         * This function tracks changes in tags related to player id, player number, win state, game start, turn start, and turn number
+         */
+        var detectTagChange = function() {
+          var match = line.match(/TAG_CHANGE Entity=(.*) tag=(.*) value=(.*)/);
+          if (match) {
             var [, player, type, state] = match;
             result = this.parseTagChange(type, player, state);
+            return true;
+          }
+        };
 
-        } else if (match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\] zone from (.*) -> (.*)/)) {
+        var detectPlayerZoneChange = function(){
+          var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\] zone from (.*) -> (.*)/);
+          if (match) {
             var [, id, local, name, entityId, zone, zonePos, cardId, playerId, fromZone, toZone] = match;
-            result = this.parseZoneChange(id, local, name, parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), fromZone, toZone)
+            result = this.parseZoneChange(id, local, name, parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), fromZone, toZone);
+            return true;
+          }
+        };
 
-        } else if (match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] zone from (.*) -> (.*)/)) {
+        var detectOpponentCardChange = function(){
+          var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] zone from (.*) -> (.*)/);
+          if (match) {
             var [, id, local, entityId, cardId, type, zone, zonePos, playerId, fromZone, toZone] = match;
-            result = this.parseZoneChange(id, local, "", parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), fromZone, toZone)
+            result = this.parseZoneChange(id, local, "", parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), fromZone, toZone);
+            return true;
+          }
+        };
 
-        } else if (match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\] pos from (\d*) -> (\d*)/)) {
+        var detectPlayerPositionZoneChange = function() {
+          var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\] pos from (\d*) -> (\d*)/);
+          if (match) {
             var [, id, local, name, entityId, zone, zonePos, cardId, playerId, fromPos, toPos] = match;
             result = this.parsePosChange(parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), parseInt(fromPos), parseInt(toPos));
+            return true;
+          }
+        };
 
-        } else if (match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] pos from (\d*) -> (\d*)/)) {
+        var detectOpponentPositionZoneChange = function() {
+          var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] pos from (\d*) -> (\d*)/);
+          if (match) {
             var [, id, local, entityId, cardId, type, zone, zonePos, playerId, fromPos, toPos] = match;
             result = this.parsePosChange(parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), parseInt(fromPos), parseInt(toPos));
+            return true;
+          }
+        };
 
-        } else if (match = line.match(/ACTION_START Entity=\[name=.* id=(\d*) .* cardId=(.*) player=(\d)\] SubType=ATTACK .* Target=\[name=.* id=(\d*) .* cardId=(.*) player=(\d)\]/)) {
-            var [, id, cardId, playerId, targetId, targetCardId, targetPlayerId] = match;
-            result = this.parseActionStart("attack", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), targetCardId, parseInt(targetPlayerId));
+        var detectAttack = function(){
+          var match = line.match(/ACTION_START Entity=\[name=.* id=(\d*) .* cardId=(.*) player=(\d)\] SubType=ATTACK .* Target=\[name=.* id=(\d*) .* cardId=(.*) player=(\d)\]/);
+          if (match) {
+              var [, id, cardId, playerId, targetId, targetCardId, targetPlayerId] = match;
+              result = this.parseActionStart("attack", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), targetCardId, parseInt(targetPlayerId));
+              return true;
+          }
+        };
 
-        } else if (match = line.match(/ACTION_START Entity=\[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\] SubType=POWER Index=(.*) Target=\[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\]/)) {
+        var detectPowerWithTarget = function(){
+          var match = line.match(/ACTION_START Entity=\[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\] SubType=POWER Index=(.*) Target=\[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\]/);
+          if (match) {
             var [, name, id, zone, zonePos, cardId, playerId, index, targetName, targetId, targetZone, targetZonePos, targetCardId, targetPlayerId] = match;
             result = this.parseActionStart("power", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), targetCardId, parseInt(targetPlayerId));
+            return true;
+          }
+        };
 
-        } else if (match = line.match(/ACTION_START Entity=\[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] SubType=POWER Index=(.*) Target=(\d*)/)) {
+        var detectPowerWithoutTarget = function(){
+          var match = line.match(/ACTION_START Entity=\[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] SubType=POWER Index=(.*) Target=(\d*)/);
+          if (match) {
             var [, id, cardId, type, zone, zonePos, playerId, index, targetId] = match;
             result = this.parseActionStart("power", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), null, null);
-        } else if (match = line.match(/ACTION_START Entity=\[name=.* id=(\d*) .* cardId=(.*) player=(\d)\] SubType=PLAY Index=(.*) Target=(\d*)/)) {
+            return true;
+          }
+        };
+
+        var detectPlay = function() {
+          var match = line.match(/ACTION_START Entity=\[name=.* id=(\d*) .* cardId=(.*) player=(\d)\] SubType=PLAY Index=(.*) Target=(\d*)/);
+          if (match) {
             var [, id, cardId, playerId, index, targetId] = match;
             result = this.parseActionStart("play", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), null, null);
+            return true;
+          }
+        };
+
+        switch (true) {
+          case initializeEngineVersion.bind(this)():
+            break;
+          case beginSpectatorMode.bind(this)():
+            break;
+          case endSpectatorMode.bind(this)():
+            break;
+          case detectCurrentMode.bind(this)():
+            break;
+          case detectChangeWithDetails.bind(this)():
+            break;
+          case detectTagChange.bind(this)():
+            break;
+          case detectPlayerZoneChange.bind(this)():
+            break;
+          case detectOpponentCardChange.bind(this)():
+            break;
+          case detectPlayerPositionZoneChange.bind(this)():
+            break;
+          case detectOpponentPositionZoneChange.bind(this)():
+            break;
+          case detectAttack.bind(this)():
+            break;
+          case detectPowerWithTarget.bind(this)() :
+            break;
+          case detectPowerWithoutTarget.bind(this)() :
+            break;
+          case detectPlay.bind(this)() :
+            break;
         }
 
         this.emit.apply(this, result);
@@ -92,15 +195,16 @@ class Parser extends EventEmitter {
                 return ["tag_change", {type: "first_player", name: playerName}];
             case "PLAYSTATE":
                 if (state == "WON" || state == "LOST") {
-                    return ["tag_change", {type: "game_over", name: playerName, state: state}];    
+                    return ["tag_change", {type: "game_over", name: playerName, state: state}];
                 }
-                break;                
+                break;
             case "TURN_START":
                 if (playerName == "GameEntity") {
                     return ["tag_change", {type: "game_start", timestamp: parseInt(state)}];
                 } else {
-                    return ["tag_change", {type: "turn_start", name: playerName, timestamp: parseInt(state)}];    
+                    return ["tag_change", {type: "turn_start", name: playerName, timestamp: parseInt(state)}];
                 }
+                break;
             case "RESOURCES":
                 return ["tag_change", {type: "resources", name: playerName, resources: parseInt(state)}];
             case "TURN":
@@ -124,11 +228,11 @@ class Parser extends EventEmitter {
     }
 
     parseZoneChange(id, local, name, entityId, zone, zonePos, cardId, playerId, fromZone, toZone) {
-        return ["zone_change", {id: entityId, player_id: playerId, card_id: cardId, from_zone: fromZone, to_zone: toZone}]
+      return ["zone_change", {id: entityId, player_id: playerId, card_id: cardId, from_zone: fromZone, to_zone: toZone}];
     }
 
     parsePosChange(entityId, zone, zonePos, cardId, playerId, fromPos, toPos) {
-        return ["pos_change", {id: entityId, player_id: playerId, card_id: cardId, from_pos: fromPos, to_pos: toPos, zone: zone}]
+      return ["pos_change", {id: entityId, player_id: playerId, card_id: cardId, from_pos: fromPos, to_pos: toPos, zone: zone}];
     }
 
     parseActionStart(type, sourceId, sourceCardId, sourcePlayerId, targetId, targetCardId, targetPlayerId) {
@@ -144,4 +248,4 @@ class Parser extends EventEmitter {
     }
 }
 
-module.exports = Parser; 
+module.exports = Parser;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -17,25 +17,25 @@ class Parser extends EventEmitter {
         var match = null;
         var result = null;
 
-        var initializeEngineVersion = function(){
-          if(line.match(/^Initialize engine version/)) {
-            result = ["startup"];
-            return true;
-          }
+        var initializeEngineVersion = function() {
+            if (line.match(/^Initialize engine version/)) {
+                result = ["startup"];
+                return true;
+            }
         };
 
         var beginSpectatorMode = function() {
-          if(line.match(/\[Power\] .* Begin Spectating/)) {
-            result = ["begin_spectator_mode"];
-            return true;
-          }
+            if (line.match(/\[Power\] .* Begin Spectating/)) {
+                result = ["begin_spectator_mode"];
+                return true;
+            }
         };
 
         var endSpectatorMode = function() {
-          if(line.match(/\[Power\] .* End Spectator/)) {
-            result = ["end_spectator_mode"];
-            return true;
-          }
+            if (line.match(/\[Power\] .* End Spectator/)) {
+                result = ["end_spectator_mode"];
+                return true;
+            }
         };
 
         var detectCurrentMode = function() {
@@ -59,133 +59,133 @@ class Parser extends EventEmitter {
         /*
          * This function tracks tag changes related to damage, attacking, defending, card target, armor, attack, and health
          */
-        var detectChangeWithDetails = function(){
-          var match = line.match(/TAG_CHANGE Entity=\[.*id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d)\] tag=(.*) value=(.*)/);
-          if (match) {
-              var [, entityId, zone, zonePos, cardId, playerId, type, state] = match;
-              result = this.parseTagChange(type, null, state, parseInt(playerId), parseInt(entityId), zone, parseInt(zonePos), cardId);
-              return true;
-          }
+        var detectChangeWithDetails = function() {
+            var match = line.match(/TAG_CHANGE Entity=\[.*id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d)\] tag=(.*) value=(.*)/);
+            if (match) {
+                var [, entityId, zone, zonePos, cardId, playerId, type, state] = match;
+                result = this.parseTagChange(type, null, state, parseInt(playerId), parseInt(entityId), zone, parseInt(zonePos), cardId);
+                return true;
+            }
         };
 
         /*
          * This function tracks changes in tags related to player id, player number, win state, game start, turn start, and turn number
          */
         var detectTagChange = function() {
-          var match = line.match(/TAG_CHANGE Entity=(.*) tag=(.*) value=(.*)/);
-          if (match) {
-            var [, player, type, state] = match;
-            result = this.parseTagChange(type, player, state);
-            return true;
-          }
+            var match = line.match(/TAG_CHANGE Entity=(.*) tag=(.*) value=(.*)/);
+            if (match) {
+                var [, player, type, state] = match;
+                result = this.parseTagChange(type, player, state);
+                return true;
+            }
         };
 
-        var detectPlayerZoneChange = function(){
-          var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\] zone from (.*) -> (.*)/);
-          if (match) {
-            var [, id, local, name, entityId, zone, zonePos, cardId, playerId, fromZone, toZone] = match;
-            result = this.parseZoneChange(id, local, name, parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), fromZone, toZone);
-            return true;
-          }
+        var detectPlayerZoneChange = function() {
+            var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\] zone from (.*) -> (.*)/);
+            if (match) {
+                var [, id, local, name, entityId, zone, zonePos, cardId, playerId, fromZone, toZone] = match;
+                result = this.parseZoneChange(id, local, name, parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), fromZone, toZone);
+                return true;
+            }
         };
 
-        var detectOpponentCardChange = function(){
-          var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] zone from (.*) -> (.*)/);
-          if (match) {
-            var [, id, local, entityId, cardId, type, zone, zonePos, playerId, fromZone, toZone] = match;
-            result = this.parseZoneChange(id, local, "", parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), fromZone, toZone);
-            return true;
-          }
+        var detectOpponentCardChange = function() {
+            var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] zone from (.*) -> (.*)/);
+            if (match) {
+                var [, id, local, entityId, cardId, type, zone, zonePos, playerId, fromZone, toZone] = match;
+                result = this.parseZoneChange(id, local, "", parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), fromZone, toZone);
+                return true;
+            }
         };
 
         var detectPlayerPositionZoneChange = function() {
-          var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\] pos from (\d*) -> (\d*)/);
-          if (match) {
-            var [, id, local, name, entityId, zone, zonePos, cardId, playerId, fromPos, toPos] = match;
-            result = this.parsePosChange(parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), parseInt(fromPos), parseInt(toPos));
-            return true;
-          }
+            var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\] pos from (\d*) -> (\d*)/);
+            if (match) {
+                var [, id, local, name, entityId, zone, zonePos, cardId, playerId, fromPos, toPos] = match;
+                result = this.parsePosChange(parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), parseInt(fromPos), parseInt(toPos));
+                return true;
+            }
         };
 
         var detectOpponentPositionZoneChange = function() {
-          var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] pos from (\d*) -> (\d*)/);
-          if (match) {
-            var [, id, local, entityId, cardId, type, zone, zonePos, playerId, fromPos, toPos] = match;
-            result = this.parsePosChange(parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), parseInt(fromPos), parseInt(toPos));
-            return true;
-          }
+            var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] pos from (\d*) -> (\d*)/);
+            if (match) {
+                var [, id, local, entityId, cardId, type, zone, zonePos, playerId, fromPos, toPos] = match;
+                result = this.parsePosChange(parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), parseInt(fromPos), parseInt(toPos));
+                return true;
+            }
         };
 
-        var detectAttack = function(){
-          var match = line.match(/ACTION_START Entity=\[name=.* id=(\d*) .* cardId=(.*) player=(\d)\] SubType=ATTACK .* Target=\[name=.* id=(\d*) .* cardId=(.*) player=(\d)\]/);
-          if (match) {
-              var [, id, cardId, playerId, targetId, targetCardId, targetPlayerId] = match;
-              result = this.parseActionStart("attack", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), targetCardId, parseInt(targetPlayerId));
-              return true;
-          }
+        var detectAttack = function() {
+            var match = line.match(/ACTION_START Entity=\[name=.* id=(\d*) .* cardId=(.*) player=(\d)\] SubType=ATTACK .* Target=\[name=.* id=(\d*) .* cardId=(.*) player=(\d)\]/);
+            if (match) {
+                var [, id, cardId, playerId, targetId, targetCardId, targetPlayerId] = match;
+                result = this.parseActionStart("attack", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), targetCardId, parseInt(targetPlayerId));
+                return true;
+            }
         };
 
-        var detectPowerWithTarget = function(){
-          var match = line.match(/ACTION_START Entity=\[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\] SubType=POWER Index=(.*) Target=\[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\]/);
-          if (match) {
-            var [, name, id, zone, zonePos, cardId, playerId, index, targetName, targetId, targetZone, targetZonePos, targetCardId, targetPlayerId] = match;
-            result = this.parseActionStart("power", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), targetCardId, parseInt(targetPlayerId));
-            return true;
-          }
+        var detectPowerWithTarget = function() {
+            var match = line.match(/ACTION_START Entity=\[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\] SubType=POWER Index=(.*) Target=\[name=(.*) id=(\d*) zone=(.*) zonePos=(\d*) cardId=(.*) player=(\d*)\]/);
+            if (match) {
+                var [, name, id, zone, zonePos, cardId, playerId, index, targetName, targetId, targetZone, targetZonePos, targetCardId, targetPlayerId] = match;
+                result = this.parseActionStart("power", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), targetCardId, parseInt(targetPlayerId));
+                return true;
+            }
         };
 
-        var detectPowerWithoutTarget = function(){
-          var match = line.match(/ACTION_START Entity=\[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] SubType=POWER Index=(.*) Target=(\d*)/);
-          if (match) {
-            var [, id, cardId, type, zone, zonePos, playerId, index, targetId] = match;
-            result = this.parseActionStart("power", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), null, null);
-            return true;
-          }
+        var detectPowerWithoutTarget = function() {
+            var match = line.match(/ACTION_START Entity=\[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] SubType=POWER Index=(.*) Target=(\d*)/);
+            if (match) {
+                var [, id, cardId, type, zone, zonePos, playerId, index, targetId] = match;
+                result = this.parseActionStart("power", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), null, null);
+                return true;
+            }
         };
 
         var detectPlay = function() {
-          var match = line.match(/ACTION_START Entity=\[name=.* id=(\d*) .* cardId=(.*) player=(\d)\] SubType=PLAY Index=(.*) Target=(\d*)/);
-          if (match) {
-            var [, id, cardId, playerId, index, targetId] = match;
-            result = this.parseActionStart("play", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), null, null);
-            return true;
-          }
+            var match = line.match(/ACTION_START Entity=\[name=.* id=(\d*) .* cardId=(.*) player=(\d)\] SubType=PLAY Index=(.*) Target=(\d*)/);
+            if (match) {
+                var [, id, cardId, playerId, index, targetId] = match;
+                result = this.parseActionStart("play", parseInt(id), cardId, parseInt(playerId), parseInt(targetId), null, null);
+                return true;
+            }
         };
 
         switch (true) {
-          case initializeEngineVersion.bind(this)():
-            break;
-          case beginSpectatorMode.bind(this)():
-            break;
-          case endSpectatorMode.bind(this)():
-            break;
-          case detectCurrentMode.bind(this)():
-            break;
-          case detectChangeWithDetails.bind(this)():
-            break;
-          case detectTagChange.bind(this)():
-            break;
-          case detectPlayerZoneChange.bind(this)():
-            break;
-          case detectOpponentCardChange.bind(this)():
-            break;
-          case detectPlayerPositionZoneChange.bind(this)():
-            break;
-          case detectOpponentPositionZoneChange.bind(this)():
-            break;
-          case detectAttack.bind(this)():
-            break;
-          case detectPowerWithTarget.bind(this)() :
-            break;
-          case detectPowerWithoutTarget.bind(this)() :
-            break;
-          case detectPlay.bind(this)() :
-            break;
+            case initializeEngineVersion.bind(this)():
+                break;
+            case beginSpectatorMode.bind(this)():
+                break;
+            case endSpectatorMode.bind(this)():
+                break;
+            case detectCurrentMode.bind(this)():
+                break;
+            case detectChangeWithDetails.bind(this)():
+                break;
+            case detectTagChange.bind(this)():
+                break;
+            case detectPlayerZoneChange.bind(this)():
+                break;
+            case detectOpponentCardChange.bind(this)():
+                break;
+            case detectPlayerPositionZoneChange.bind(this)():
+                break;
+            case detectOpponentPositionZoneChange.bind(this)():
+                break;
+            case detectAttack.bind(this)():
+                break;
+            case detectPowerWithTarget.bind(this)():
+                break;
+            case detectPowerWithoutTarget.bind(this)():
+                break;
+            case detectPlay.bind(this)():
+                break;
         }
 
         this.emit.apply(this, result);
         return result;
-    }
+        }
 
     parseTagChange(type, playerName, state, playerId, entityId, zone, zonePos, cardId) {
         switch(type) {


### PR DESCRIPTION
Hi @siuying,
The purpose of this commit is to remove the large if/else statement in favor of a switch statement which allows each testing condition to become its own function. This makes the code easier to read and test in isolation. Additionally, I noticed that one of the tests was passing from a matcher which was overly generic. 

I rewrote the matcher that tested the opponent zone change like this:

``` javascript
var match = line.match(/\[Zone\] ZoneChangeList\.ProcessChanges\(\) - id=(\d*) local=(.*) \[id=(\d*) cardId=(.*) type=(.*) zone=(.*) zonePos=(\d*) player=(\d*)\] pos from (\d*) -> (\d*)/);
if (match) {
  var [, id, local, entityId, cardId, type, zone, zonePos, playerId, fromPos, toPos] = match;
  result = this.parsePosChange(parseInt(entityId), zone, parseInt(zonePos), cardId, parseInt(playerId), parseInt(fromPos), parseInt(toPos));
  return true;
}
```

This is to better match the test which was looking for a structure like this:

``` bash
"[Zone] ZoneChangeList.ProcessChanges() - id=1 local=False [id=10 cardId= type=INVALID zone=HAND zonePos=3 player=1] pos from 0 -> 3";
```

Please let me know if I misunderstood the intent of this matcher and instead made it overly specific. However, all tests still pass so I hope we are good. 

This PR is part of a larger effort I have underway to add rollup metrics as part of the data object. This way the calculations can be done at the point the match is complete.
